### PR TITLE
Fix numerical instabilities

### DIFF
--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -4,7 +4,6 @@ import unittest
 from chainer import cuda
 from chainer import function
 from chainer import functions
-from chainer.testing import condition
 from chainer import variable
 
 try:
@@ -208,8 +207,10 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
                     'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4,
                     'dtype': numpy.float64}
             else:
-                self.backward_options = {'atol': 1e-4, 'rtol': 1e-4}
-                self.double_backward_options = {'atol': 1e-4, 'rtol': 1e-4}
+                self.backward_options = {
+                    'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-4}
+                self.double_backward_options = {
+                    'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-4}
             if backward_options is not None:
                 self.backward_options.update(backward_options)
             if double_backward_options is not None:
@@ -224,13 +225,11 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
             testing.assert_allclose(y_expected, y.data, atol=1e-4, rtol=1e-4)
         setattr(klass, "check_forward", check_forward)
 
-        @condition.retry(3)
         def test_forward_cpu(self):
             self.check_forward(self.x)
         setattr(klass, "test_forward_cpu", test_forward_cpu)
 
         @attr.gpu
-        @condition.retry(3)
         def test_forward_gpu(self):
             self.check_forward(cuda.to_gpu(self.x))
         setattr(klass, "test_forward_gpu", test_forward_gpu)
@@ -240,13 +239,11 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
                 func, x_data, y_grad, **self.backward_options)
         setattr(klass, "check_backward", check_backward)
 
-        @condition.retry(3)
         def test_backward_cpu(self):
             self.check_backward(self.x, self.gy)
         setattr(klass, "test_backward_cpu", test_backward_cpu)
 
         @attr.gpu
-        @condition.retry(3)
         def test_backward_gpu(self):
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
         setattr(klass, "test_backward_gpu", test_backward_gpu)
@@ -259,14 +256,12 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
                     x_grad_grad, **self.double_backward_options)
             setattr(klass, "check_double_backward", check_double_backward)
 
-            @condition.retry(3)
             def test_double_backward_cpu(self):
                 self.check_double_backward(self.x, self.gy, self.ggx)
             setattr(klass, "test_double_backward_cpu",
                     test_double_backward_cpu)
 
             @attr.gpu
-            @condition.retry(3)
             def test_double_backward_gpu(self):
                 self.check_double_backward(
                     cuda.to_gpu(self.x), cuda.to_gpu(self.gy),

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -27,6 +27,13 @@ class TestClippedReLU(unittest.TestCase):
         self.ggx = numpy.random.uniform(-1, 1, x.shape).astype(self.dtype)
         self.z = 0.75
 
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {}
+            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+        else:
+            self.check_backward_options = {}
+            self.check_double_backward_options = {}
+
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.clipped_relu(x, self.z)
@@ -48,7 +55,8 @@ class TestClippedReLU(unittest.TestCase):
             return functions.clipped_relu(x, self.z)
 
         gradient_check.check_backward(
-            f, x_data, y_grad, dtype=numpy.float64)
+            f, x_data, y_grad, dtype=numpy.float64,
+            **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
@@ -63,7 +71,8 @@ class TestClippedReLU(unittest.TestCase):
             return y * y
 
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64)
+            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -30,9 +30,11 @@ class TestSigmoid(unittest.TestCase):
 
         self.check_forward_options = {}
         self.check_backward_options = {}
+        self.check_double_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 5e-2}
+            self.check_double_backward_options = {'atol': 1e-2, 'rtol': 5e-2}
 
     def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
@@ -85,7 +87,8 @@ class TestSigmoid(unittest.TestCase):
 
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
-                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64)
+                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import type_check
 
 
@@ -45,8 +44,8 @@ class TestBroadcast(unittest.TestCase):
         self.check_backward_options = {}
         self.check_double_backward_options = {}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
+            self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
 
     def check_forward(self, data):
         xs = [chainer.Variable(x) for x in data]
@@ -149,7 +148,7 @@ class TestBroadcastTo(unittest.TestCase):
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2 ** -5, 'atol': 1e-3, 'rtol': 1e-2}
+                'eps': 2 ** -5, 'atol': 1e-2, 'rtol': 1e-1}
 
     def check_forward(self, data):
         x = chainer.Variable(data)
@@ -164,13 +163,11 @@ class TestBroadcastTo(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.data))
 
-    @condition.retry(3)
     def check_backward(self, data, grads):
         gradient_check.check_backward(
             lambda x: functions.broadcast_to(x, self.out_shape), data, grads,
             dtype=numpy.float64, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.data, self.grad)
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -22,6 +21,9 @@ class TestSpatialTransformerGrid(unittest.TestCase):
         self.output_shape = (5, 6)
         self.grads = numpy.random.uniform(
             size=(B, 2) + self.output_shape).astype(self.theta.dtype)
+
+        self.check_backward_options = {
+            'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, theta, output_shape):
         grid = functions.spatial_transformer_grid(theta, output_shape).data
@@ -52,14 +54,13 @@ class TestSpatialTransformerGrid(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             gradient_check.check_backward(
                 functions.SpatialTransformerGrid(output_shape),
-                (theta,), (grads,), atol=1e-4, rtol=1e-3)
+                (theta,), (grads,), dtype=numpy.float64,
+                **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.theta, self.output_shape, self.grads)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             self.check_backward(cuda.to_gpu(self.theta), self.output_shape,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(
@@ -42,26 +41,22 @@ class TestAbsoluteError(unittest.TestCase):
             loss_expect = abs(self.x0[i] - self.x1[i])
             self.assertAlmostEqual(loss_value[i], loss_expect, places=5)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x0, self.x1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
     def check_backward(self, x0_data, x1_data, y_grad):
         gradient_check.check_backward(
             functions.AbsoluteError(),
-            (x0_data, x1_data), y_grad, dtype='d', eps=1e-2)
+            (x0_data, x1_data), y_grad, dtype='d')
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x0, self.x1, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x0), cuda.to_gpu(self.x1), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -32,7 +32,7 @@ class TestContrastive(unittest.TestCase):
             self.gy = numpy.random.uniform(
                 -1, 1, (self.batchsize,)).astype(numpy.float32)
 
-        self.check_backward_options = {'rtol': 1e-2, 'atol': 1e-3 }
+        self.check_backward_options = {'rtol': 1e-2, 'atol': 1e-3}
 
     def check_forward(self, x0_data, x1_data, t_data):
         x0_val = chainer.Variable(x0_data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -10,7 +10,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(
@@ -32,6 +31,8 @@ class TestContrastive(unittest.TestCase):
         else:
             self.gy = numpy.random.uniform(
                 -1, 1, (self.batchsize,)).astype(numpy.float32)
+
+        self.check_backward_options = {'rtol': 1e-2, 'atol': 1e-3 }
 
     def check_forward(self, x0_data, x1_data, t_data):
         x0_val = chainer.Variable(x0_data)
@@ -58,7 +59,7 @@ class TestContrastive(unittest.TestCase):
             loss_expect[i] /= 2.
         if self.reduce == 'mean':
             loss_expect = numpy.sum(loss_expect) / self.t.shape[0]
-        numpy.testing.assert_allclose(loss_expect, loss_value, rtol=1e-5)
+        numpy.testing.assert_allclose(loss_expect, loss_value, rtol=1e-2)
 
     def test_negative_margin(self):
         self.margin = -1
@@ -67,12 +68,10 @@ class TestContrastive(unittest.TestCase):
         self.assertRaises(ValueError, self.check_backward,
                           self.x0, self.x1, self.t, self.gy)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x0, self.x1, self.t)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
                            cuda.to_gpu(self.t))
@@ -81,24 +80,20 @@ class TestContrastive(unittest.TestCase):
         gradient_check.check_backward(
             functions.Contrastive(self.margin, self.reduce),
             (x0_data, x1_data, t_data), gy_data, dtype='d',
-            rtol=1e-3, atol=1e-4)
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x0, self.x1, self.t, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
                             cuda.to_gpu(self.t), cuda.to_gpu(self.gy))
 
-    @condition.retry(3)
     def test_backward_zero_dist_cpu(self):
         self.check_backward(self.x0, self.x0, self.t, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_zero_dist_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x0),
                             cuda.to_gpu(self.t), cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -9,7 +9,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -20,13 +19,16 @@ from chainer.testing import condition
 class TestHinge(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (10, 5)).astype(numpy.float32)
+        shape = (10, 5)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
         # Avoid values around -1.0 for stability
         self.x[numpy.logical_and(-1.01 < self.x, self.x < -0.99)] = 0.5
-        self.t = numpy.random.randint(0, 5, (10,)).astype(self.label_dtype)
+        self.t = numpy.random.randint(0, shape[1], shape[:1]).astype(self.label_dtype)
         if self.reduce == 'no':
             self.gy = numpy.random.uniform(
                 -1, 1, self.x.shape).astype(numpy.float32)
+
+        self.check_backward_options = {'atol': 1e-1, 'rtol': 1e-1}
 
     def check_forward(self, x_data, t_data):
         x_val = chainer.Variable(x_data)
@@ -54,26 +56,23 @@ class TestHinge(unittest.TestCase):
 
         testing.assert_allclose(loss_expect, loss_value)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     def check_backward(self, x_data, t_data):
         gradient_check.check_backward(
             functions.Hinge(self.norm), (x_data, t_data), None,
-            dtype='d', rtol=1e-3, atol=1e-4)
+            dtype='d',
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -23,7 +23,8 @@ class TestHinge(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
         # Avoid values around -1.0 for stability
         self.x[numpy.logical_and(-1.01 < self.x, self.x < -0.99)] = 0.5
-        self.t = numpy.random.randint(0, shape[1], shape[:1]).astype(self.label_dtype)
+        self.t = numpy.random.randint(
+            0, shape[1], shape[:1]).astype(self.label_dtype)
         if self.reduce == 'no':
             self.gy = numpy.random.uniform(
                 -1, 1, self.x.shape).astype(numpy.float32)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_huber_loss.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(
@@ -28,6 +27,8 @@ class TestHuberLoss(unittest.TestCase):
             gy_shape = self.shape
         self.gy = numpy.random.random(gy_shape).astype(numpy.float32)
 
+        self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
@@ -44,26 +45,23 @@ class TestHuberLoss(unittest.TestCase):
             loss_expect = numpy.sum(loss_expect, axis=1)
         testing.assert_allclose(loss_value, loss_expect)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
     def check_backward(self, x_data, t_data, y_grad):
         gradient_check.check_backward(
             functions.HuberLoss(delta=1, reduce=self.reduce),
-            (x_data, t_data), y_grad, eps=1e-2, atol=1e-3)
+            (x_data, t_data), y_grad, eps=1e-2,
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t),
                             cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -10,7 +10,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*(testing.product({
@@ -61,9 +60,14 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, ()).astype(self.x.dtype)
         self.ggx = numpy.random.uniform(
             -1, 1, self.x.shape).astype(self.x.dtype)
-        self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-        self.check_backward_options = {
-            'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         if self.weight_apply:
             self.class_weight = numpy.random.uniform(
                 0, 10, (self.x.shape[1],)).astype(self.dtype)
@@ -114,19 +118,16 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         testing.assert_allclose(
             loss_expect, loss_value, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
             None if not self.weight_apply else cuda.to_gpu(self.class_weight))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
@@ -141,19 +142,16 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
                 func, (x_data, t_data), None,
                 **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
             None if not self.weight_apply else cuda.to_gpu(self.class_weight))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
@@ -175,13 +173,11 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
                 f, x_data, gy_data, ggx_data,
                 **self.check_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(
             self.x, self.t, self.gy, self.ggx, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
@@ -189,7 +185,6 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             None if not self.weight_apply else cuda.to_gpu(self.class_weight))
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu_no_cudnn(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.t),
@@ -346,9 +341,14 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
                 self.t[self.ignore_index] = -1
         self.g = numpy.random.uniform(-1, 1, self.t.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
-        self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-        self.check_backward_options = {
-            'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         if self.weight_apply:
             self.class_weight = numpy.random.uniform(
                 0, 10, (self.x.shape[1],)).astype(self.dtype)
@@ -384,13 +384,11 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
             testing.assert_allclose(
                 loss_expect, li, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             self.check_forward(self.x, self.t, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         if not self.weight_apply:
             weight = None
@@ -409,13 +407,11 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
             func, (x_data, t_data), g_data,
             **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             self.check_backward(self.x, self.t, self.g, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         if not self.weight_apply:
             weight = None
@@ -441,14 +437,12 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
             f, x_data, g_data, ggx_data,
             **self.check_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             self.check_double_backward(
                 self.x, self.t, self.g, self.ggx, self.class_weight)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         if not self.weight_apply:
             weight = None
@@ -524,12 +518,10 @@ class TestNonDefaultIgnoreLabel(unittest.TestCase):
             expect = numpy.zeros((2,), dtype=numpy.float32)
         testing.assert_allclose(loss.data, expect)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(numpy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.cupy)
 
@@ -550,12 +542,10 @@ class TestNonDefaultIgnoreLabel(unittest.TestCase):
 
         gradient_check.check_backward(f, (x, t), gy)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(numpy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.cupy)
 
@@ -577,12 +567,10 @@ class TestNonDefaultIgnoreLabel(unittest.TestCase):
 
         gradient_check.check_double_backward(f, x, gy, ggx)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(numpy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(cuda.cupy)
 
@@ -655,12 +643,10 @@ class TestForwardConsistency(unittest.TestCase):
         testing.assert_allclose(
             loss_single, loss_double, **check_forward_options)
 
-    @condition.retry(3)
     def test_consistency_cpu(self):
         self.check_consistency(numpy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_consistency_gpu(self):
         self.check_consistency(cuda.cupy)
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_average.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_average.py
@@ -9,7 +9,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*(
@@ -47,9 +46,14 @@ class TestAverage(unittest.TestCase):
 
         # Sample weights. Weights should not sum to 0.
         while True:
-            self.w = numpy.random.uniform(-1, 1, w_shape).astype(self.dtype)
-            if self.w.sum() > 1e-4:
+            self.w = numpy.random.uniform(-2, 2, w_shape).astype(self.dtype)
+            if self.w.sum() > 1e-2:
                 break
+
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
+        else:
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, x_data, axis, weights):
         if self.use_weights and isinstance(self.axis, tuple):
@@ -87,12 +91,10 @@ class TestAverage(unittest.TestCase):
         self.assertEqual(y_expect.shape, y.shape)
         testing.assert_allclose(y_expect, y.data, **options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.axis, self.w)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(
             cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.w))
@@ -113,15 +115,13 @@ class TestAverage(unittest.TestCase):
             args = x_data
 
         gradient_check.check_backward(
-            f, args, y_grad, atol=1e-2, rtol=1e-2,
-            dtype=numpy.float64)
+            f, args, y_grad, dtype=numpy.float64,
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy, self.axis, self.w)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), self.axis,

--- a/tests/chainer_tests/functions_tests/math_tests/test_hyperbolic.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_hyperbolic.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 class UnaryFunctionsTestBase(unittest.TestCase):
@@ -18,6 +17,11 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 
     def setUp(self):
         self.x, self.gy = self.make_data()
+
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2 }
+        else:
+            self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3 }
 
     def check_forward(self, op, op_xp, x_data):
         x = chainer.Variable(x_data)
@@ -33,7 +37,8 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 
     def check_backward(self, op, x_data, y_grad):
         gradient_check.check_backward(
-            op, x_data, y_grad, atol=1e-4, rtol=1e-3, dtype=numpy.float64)
+            op, x_data, y_grad, dtype=numpy.float64,
+            **self.check_backward_options)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
@@ -56,21 +61,17 @@ class TestCosh(UnaryFunctionsTestBase):
         gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x, gy
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward_cpu(F.cosh, numpy.cosh)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward_gpu(F.cosh, cuda.cupy.cosh)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward_cpu(F.cosh)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward_gpu(F.cosh)
 
@@ -89,21 +90,17 @@ class TestSinh(UnaryFunctionsTestBase):
         gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x, gy
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward_cpu(F.sinh, numpy.sinh)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward_gpu(F.sinh, cuda.cupy.sinh)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward_cpu(F.sinh)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward_gpu(F.sinh)
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_hyperbolic.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_hyperbolic.py
@@ -19,9 +19,9 @@ class UnaryFunctionsTestBase(unittest.TestCase):
         self.x, self.gy = self.make_data()
 
         if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2 }
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
         else:
-            self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3 }
+            self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, op, op_xp, x_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_logsumexp.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_logsumexp.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(
@@ -23,11 +22,11 @@ class TestLogSumExp(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, ()).astype(self.dtype)
         self.check_forward_option = {}
         self.check_backward_option = {
-            'eps': 2.0 ** -5, 'rtol': 1.0e-4, 'atol': 1.0e-4}
+            'eps': 2.0 ** -5, 'rtol': 1e-4, 'atol': 1e-4}
         if self.dtype == numpy.float16:
-            self.check_forward_option = {'rtol': 1.0e-2, 'atol': 1.0e-2}
+            self.check_forward_option = {'rtol': 1e-2, 'atol': 1e-2}
             self.check_backward_option = {
-                'eps': 2.0 ** -3, 'rtol': 1.0e-2, 'atol': 1.0e-2}
+                'eps': 2.0 ** -3, 'rtol': 1e-1, 'atol': 1e-1}
 
     def check_forward(self, x_data, axis=None):
         x = chainer.Variable(x_data)
@@ -37,68 +36,54 @@ class TestLogSumExp(unittest.TestCase):
         testing.assert_allclose(
             y_expect, y.data, **self.check_forward_option)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
-    @condition.retry(3)
     def test_forward_axis_cpu(self):
         for i in range(self.x.ndim):
             self.check_forward(self.x, axis=i)
 
-    @condition.retry(3)
     def test_forward_negative_axis_cpu(self):
         self.check_forward(self.x, axis=-1)
 
-    @condition.retry(3)
     def test_forward_multi_axis_cpu(self):
         self.check_forward(self.x, axis=(0, 1))
 
-    @condition.retry(3)
     def test_forward_multi_axis_invert_cpu(self):
         self.check_forward(self.x, axis=(1, 0))
 
-    @condition.retry(3)
     def test_forward_negative_multi_axis_cpu(self):
         self.check_forward(self.x, axis=(0, -1))
 
-    @condition.retry(3)
     def test_forward_negative_multi_axis_invert_cpu(self):
         self.check_forward(self.x, axis=(-2, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_axis_gpu(self):
         for i in range(self.x.ndim):
             self.check_forward(cuda.to_gpu(self.x), axis=i)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_negative_axis_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), axis=-1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_multi_axis_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), axis=(0, 1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_multi_axis_invert_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), axis=(1, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_negative_multi_axis_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), axis=(0, -1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_negative_multi_axis_invert_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), axis=(-2, 0))
 
@@ -107,80 +92,66 @@ class TestLogSumExp(unittest.TestCase):
             functions.LogSumExp(axis), x_data, y_grad,
             **self.check_backward_option)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @condition.retry(3)
     def test_backward_axis_cpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=i)) * self.gy
             self.check_backward(self.x, gy, axis=i)
 
-    @condition.retry(3)
     def test_backward_negative_axis_cpu(self):
         gy = numpy.ones_like(self.x.sum(axis=-1)) * self.gy
         self.check_backward(self.x, gy, axis=-1)
 
-    @condition.retry(3)
     def test_backward_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, 1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, 1))
 
-    @condition.retry(3)
     def test_backward_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(1, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(1, 0))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, -1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, -1))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(-2, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(-2, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=i)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=i)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=-1)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=-1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, 1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, 1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(1, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(1, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, -1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, -1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(-2, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(-2, 0))

--- a/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import type_check
 
 
@@ -20,21 +19,26 @@ class TestMaximum(unittest.TestCase):
 
     def setUp(self):
         shape = self.shape
-        self.x1 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.x2 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        # Avoid close values for stability in numerical gradient.
-        for i in numpy.ndindex(shape):
-            if -0.125 < self.x1[i] - self.x2[i] < 0.125:
-                self.x1[i] = -0.5
-                self.x2[i] = 0.5
-        self.y_expected = numpy.maximum(self.x1, self.x2)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.check_forward_options = {}
         self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
+            eps = 2 ** -3
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
+        else:
+            eps = 1e-2
+        self.check_backward_options['eps'] = eps
+
+        self.x1 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.x2 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+
+        # Avoid close values for stability in numerical gradient.
+        idx = abs(self.x1 - self.x2) < 2 * eps
+        self.x1[idx] = -0.5
+        self.x2[idx] = 0.5
+
+        self.y_expected = numpy.maximum(self.x1, self.x2)
 
     def check_forward(self, x1_data, x2_data, y_expected):
         x1 = chainer.Variable(x1_data)
@@ -44,12 +48,10 @@ class TestMaximum(unittest.TestCase):
         testing.assert_allclose(
             y_expected, y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x1, self.x2, self.y_expected)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         x1 = cuda.to_gpu(self.x1)
         x2 = cuda.to_gpu(self.x2)
@@ -61,12 +63,10 @@ class TestMaximum(unittest.TestCase):
         gradient_check.check_backward(
             func, x, y_grad, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         x1 = cuda.to_gpu(self.x1)
         x2 = cuda.to_gpu(self.x2)

--- a/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import type_check
 
 
@@ -20,21 +19,26 @@ class TestMinimum(unittest.TestCase):
 
     def setUp(self):
         shape = self.shape
-        self.x1 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.x2 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        # Avoid close values for stability in numerical gradient.
-        for i in numpy.ndindex(shape):
-            if -0.125 < self.x1[i] - self.x2[i] < 0.125:
-                self.x1[i] = -0.5
-                self.x2[i] = 0.5
-        self.y_expected = numpy.minimum(self.x1, self.x2)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.check_forward_options = {}
-        self.check_backward_options = {'eps': 1e-2}
+        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
+            eps = 2 ** -3
             self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-            self.check_backward_options = {
-                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
+        else:
+            eps = 1e-2
+        self.check_backward_options['eps'] = eps
+
+        self.x1 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.x2 = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+
+        # Avoid close values for stability in numerical gradient.
+        idx = abs(self.x1 - self.x2) < 2 * eps
+        self.x1[idx] = -0.5
+        self.x2[idx] = 0.5
+
+        self.y_expected = numpy.minimum(self.x1, self.x2)
 
     def check_forward(self, x1_data, x2_data, y_expected):
         x1 = chainer.Variable(x1_data)
@@ -44,12 +48,10 @@ class TestMinimum(unittest.TestCase):
         testing.assert_allclose(
             y_expected, y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x1, self.x2, self.y_expected)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         x1 = cuda.to_gpu(self.x1)
         x2 = cuda.to_gpu(self.x2)
@@ -61,12 +63,10 @@ class TestMinimum(unittest.TestCase):
         gradient_check.check_backward(
             func, x, y_grad, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         x1 = cuda.to_gpu(self.x1)
         x2 = cuda.to_gpu(self.x2)

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -15,7 +15,8 @@ class TestMax(unittest.TestCase):
     def setUp(self):
         # Sample x with single maximum value
         while True:
-            self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+            self.x = numpy.random.uniform(
+                -1, 1, (3, 2, 4)).astype(numpy.float32)
             if (self.x > (numpy.max(self.x) - 1e-2)).sum() == 1:
                 break
 
@@ -190,13 +191,13 @@ class TestMin(unittest.TestCase):
     def setUp(self):
         # Sample x with single minimum value
         while True:
-            self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+            self.x = numpy.random.uniform(
+                -1, 1, (3, 2, 4)).astype(numpy.float32)
             if (self.x < (numpy.min(self.x) + 1e-2)).sum() == 1:
                 break
 
         self.gy = numpy.array(2, dtype=numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
-
 
     def check_forward(self, x_data, axis=None, keepdims=False):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -8,13 +8,17 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 class TestMax(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+        # Sample x with single maximum value
+        while True:
+            self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+            if (self.x > (numpy.max(self.x) - 1e-2)).sum() == 1:
+                break
+
         self.gy = numpy.array(2, dtype=numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
 
@@ -82,80 +86,66 @@ class TestMax(unittest.TestCase):
             lambda x: functions.max(x, axis, keepdims),
             x_data, y_grad, dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @condition.retry(3)
     def test_backward_axis_cpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.max(axis=i)) * self.gy
             self.check_backward(self.x, gy, axis=i)
 
-    @condition.retry(3)
     def test_backward_negative_axis_cpu(self):
         gy = numpy.ones_like(self.x.max(axis=-1)) * self.gy
         self.check_backward(self.x, gy, axis=-1)
 
-    @condition.retry(3)
     def test_backward_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.max(axis=(0, 1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, 1))
 
-    @condition.retry(3)
     def test_backward_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.max(axis=(1, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(1, 0))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.max(axis=(0, -1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, -1))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.max(axis=(-2, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(-2, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=i)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=i)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=-1)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=-1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, 1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, 1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(1, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(1, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, -1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, -1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(-2, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(-2, 0))
@@ -170,12 +160,10 @@ class TestMax(unittest.TestCase):
             f, x_data, y_grad, x_grad_grad,
             dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
@@ -200,9 +188,15 @@ class TestMax(unittest.TestCase):
 class TestMin(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+        # Sample x with single minimum value
+        while True:
+            self.x = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+            if (self.x < (numpy.min(self.x) + 1e-2)).sum() == 1:
+                break
+
         self.gy = numpy.array(2, dtype=numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+
 
     def check_forward(self, x_data, axis=None, keepdims=False):
         x = chainer.Variable(x_data)
@@ -266,82 +260,68 @@ class TestMin(unittest.TestCase):
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
             lambda x: functions.min(x, axis=axis, keepdims=keepdims),
-            x_data, y_grad, eps=1e-4, rtol=1e-3, atol=1e-3)
+            x_data, y_grad, dtype='d', eps=1e-4, rtol=1e-3, atol=1e-3)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
-    @condition.retry(3)
     def test_backward_axis_cpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.min(axis=i)) * self.gy
             self.check_backward(self.x, gy, axis=i)
 
-    @condition.retry(3)
     def test_backward_negative_axis_cpu(self):
         gy = numpy.ones_like(self.x.min(axis=-1)) * self.gy
         self.check_backward(self.x, gy, axis=-1)
 
-    @condition.retry(3)
     def test_backward_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.min(axis=(0, 1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, 1))
 
-    @condition.retry(3)
     def test_backward_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.min(axis=(1, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(1, 0))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_cpu(self):
         gy = numpy.ones_like(self.x.min(axis=(0, -1))) * self.gy
         self.check_backward(self.x, gy, axis=(0, -1))
 
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_cpu(self):
         gy = numpy.ones_like(self.x.min(axis=(-2, 0))) * self.gy
         self.check_backward(self.x, gy, axis=(-2, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=i)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=i)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_axis_gpu(self):
         for i in range(self.x.ndim):
             gy = numpy.ones_like(self.x.sum(axis=-1)) * self.gy
             self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=-1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, 1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, 1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(1, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(1, 0))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(0, -1))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(0, -1))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_negative_multi_axis_invert_gpu(self):
         gy = numpy.ones_like(self.x.sum(axis=(-2, 0))) * self.gy
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(gy), axis=(-2, 0))
@@ -356,12 +336,10 @@ class TestMin(unittest.TestCase):
             f, x_data, y_grad, x_grad_grad,
             dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
@@ -432,12 +410,10 @@ class TestArgMinMax(unittest.TestCase):
         y.backward()
         self.assertIsNone(x.grad)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x))
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_scale.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_scale.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 class TestScale(unittest.TestCase):
@@ -21,6 +20,8 @@ class TestScale(unittest.TestCase):
         for i, j, k in numpy.ndindex(self.y_expected.shape):
             self.y_expected[i, j, k] *= self.x2[j]
         self.gy = numpy.random.uniform(-1, 1, (3, 2, 3)).astype(numpy.float32)
+
+        self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, x1_data, x2_data, axis, y_expected):
         x1 = chainer.Variable(x1_data)
@@ -41,14 +42,13 @@ class TestScale(unittest.TestCase):
         x = (x1_data, x2_data)
         gradient_check.check_backward(
             lambda x, y: functions.scale(x, y, axis),
-            x, y_grad)
+            x, y_grad,
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.axis, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         x1 = cuda.to_gpu(self.x1)
         x2 = cuda.to_gpu(self.x2)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -18,7 +18,8 @@ def make_data(shape, dtype):
 @testing.unary_math_function_unittest(
     F.sqrt,
     make_data=make_data,
-    backward_options={'atol': 1e-3, 'rtol': 1e-3},
+    backward_options={'eps': 1e-3},
+    double_backward_options={'eps': 1e-3},
 )
 class TestSqrt(unittest.TestCase):
     pass

--- a/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -27,10 +26,9 @@ class TrigonometricFunctionsTest(unittest.TestCase):
         self.np_func = getattr(numpy, self.func_name)
 
         if self.dtype == numpy.float16:
-            self.backward_options = {
-                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+            self.backward_options = {'eps': 1e-3, 'atol': 1e-2, 'rtol': 1e-2}
         else:
-            self.backward_options = {}
+            self.backward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
@@ -38,25 +36,21 @@ class TrigonometricFunctionsTest(unittest.TestCase):
         testing.assert_allclose(
             self.np_func(self.x), y.data, atol=1e-4, rtol=1e-4)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            self.func, x_data, y_grad, **self.backward_options)
+            self.func, x_data, y_grad, dtype='d', **self.backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
@@ -99,10 +93,13 @@ class TestArctan2(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         if self.dtype == numpy.float16:
             self.backward_options = {
-                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+                'eps': 1e-3, 'atol': 2 ** -4, 'rtol': 2 ** -4}
         else:
             self.backward_options = {
                 'atol': 1e-3, 'rtol': 1e-3}
+
+        # Avoid non-differentiable point
+        self.x1[(abs(self.x1) < 1e-2) & (self.x2 < 0)] = 1
 
     def check_forward(self, x1_data, x2_data):
         y = F.arctan2(x1_data, x2_data)
@@ -115,25 +112,21 @@ class TestArctan2(unittest.TestCase):
         testing.assert_allclose(
             numpy.arctan2(self.x1, self.x2), y.data, atol=1e-4, rtol=1e-4)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x1, self.x2)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     def check_backward(self, x1_data, x2_data, y_grad):
         gradient_check.check_backward(
-            F.arctan2, (x1_data, x2_data), y_grad, **self.backward_options)
+            F.arctan2, (x1_data, x2_data), y_grad, dtype='d', **self.backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x1),
                             cuda.to_gpu(self.x2),

--- a/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_trigonometric.py
@@ -121,7 +121,8 @@ class TestArctan2(unittest.TestCase):
 
     def check_backward(self, x1_data, x2_data, y_grad):
         gradient_check.check_backward(
-            F.arctan2, (x1_data, x2_data), y_grad, dtype='d', **self.backward_options)
+            F.arctan2, (x1_data, x2_data), y_grad, dtype='d',
+            **self.backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x1, self.x2, self.gy)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 def _dropout(x, creator):
@@ -32,7 +31,7 @@ class TestDropout(unittest.TestCase):
         self.check_double_backward_options = {'dtype': 'd'}
         if self.dtype == numpy.float16:
             self.check_double_backward_options = {
-                'dtype': 'd', 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': 'd', 'atol': 1e-3, 'rtol': 1e-2}
 
     def check_type_forward(self, x_data):
         x = chainer.Variable(x_data)
@@ -72,12 +71,10 @@ class TestDropout(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x),
                             cuda.to_gpu(self.gy))
@@ -93,12 +90,10 @@ class TestDropout(unittest.TestCase):
             f, x_data, y_grad, x_grad_grad,
             **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(cuda.to_gpu(self.x),
                                    cuda.to_gpu(self.gy),

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -20,6 +19,8 @@ class TestGaussian(unittest.TestCase):
         self.m = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         self.v = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2 }
 
     def check_forward(self, m_data, v_data):
         m = chainer.Variable(m_data)
@@ -40,14 +41,12 @@ class TestGaussian(unittest.TestCase):
     def check_backward(self, m_data, v_data, y_grad):
         gradient_check.check_backward(
             functions.Gaussian(), (m_data, v_data), y_grad,
-            atol=1e-4, rtol=1e-3)
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.m, self.v, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.m),
                             cuda.to_gpu(self.v),

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -20,7 +20,7 @@ class TestGaussian(unittest.TestCase):
         self.v = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
 
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2 }
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, m_data, v_data):
         m = chainer.Variable(m_data)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -31,14 +31,14 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(self.x_dtype)
         self.y = self.x.dot(self.W.T) + self.b
         self.check_forward_options = {}
-        self.check_backward_options = {}
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
         if self.x_dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
         elif self.W_dtype == numpy.float16:
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, x_data, W_data, b_data):
         # Check only data type, y is tested by SimplifiedDropconnect link test.

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -10,7 +10,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 def _batch_normalization(expander, gamma, beta, x, mean, var):
@@ -64,6 +63,8 @@ class TestBatchNormalization(unittest.TestCase):
             self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+            self.check_double_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def batch_normalization(self, *args):
         return functions.batch_normalization(
@@ -82,22 +83,18 @@ class TestBatchNormalization(unittest.TestCase):
         testing.assert_allclose(
             y_expect, y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.args)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args])
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args], 'never')
 
     @attr.cudnn
-    @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward([cuda.cupy.asfortranarray(cuda.to_gpu(i))
                             for i in self.args])
@@ -109,24 +106,20 @@ class TestBatchNormalization(unittest.TestCase):
                 self.batch_normalization, args, y_grad,
                 **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.args, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy), 'never')
 
     @attr.cudnn
-    @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(
             [cuda.cupy.asfortranarray(cuda.to_gpu(i)) for i in self.args],
@@ -143,19 +136,16 @@ class TestBatchNormalization(unittest.TestCase):
                 f, args, y_grad, x_grad_grad,
                 **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.args, self.gy, self.ggargs)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             [cuda.to_gpu(x) for x in self.args], cuda.to_gpu(self.gy),
             [cuda.to_gpu(ggx) for ggx in self.ggargs])
 
     @attr.cudnn
-    @condition.retry(3)
     def test_double_backward_gpu_non_contiguous(self):
         self.check_double_backward(
             [cuda.cupy.asfortranarray(cuda.to_gpu(x)) for x in self.args],
@@ -228,22 +218,18 @@ class TestFixedBatchNormalization(unittest.TestCase):
         testing.assert_allclose(
             y_expect, y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.args)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args])
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args], 'never')
 
     @attr.cudnn
-    @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward([cuda.cupy.asfortranarray(cuda.to_gpu(i))
                             for i in self.args])
@@ -255,24 +241,20 @@ class TestFixedBatchNormalization(unittest.TestCase):
                 self.batch_normalization, args, y_grad,
                 **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.args, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(
             [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy), 'never')
 
     @attr.cudnn
-    @condition.retry(3)
     def test_backward_gpu_no_contiguous(self):
         self.check_backward(
             [cuda.cupy.asfortranarray(cuda.to_gpu(i)) for i in self.args],
@@ -288,7 +270,6 @@ class TestFixedBatchNormalization(unittest.TestCase):
                 f, args, y_grad, x_grad_grad,
                 **self.check_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.args, self.gy, self.ggargs)
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -10,7 +10,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(
@@ -48,26 +47,22 @@ class TestL2Normalization(unittest.TestCase):
             y_expect[index] = self.x[index] / numerator
         testing.assert_allclose(y_expect, y_data)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.axis)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x), self.axis)
 
     def check_backward(self, x_data, axis, y_grad):
         gradient_check.check_backward(
             functions.NormalizeL2(eps=1e-6, axis=axis), x_data, y_grad,
-            dtype='d', rtol=1e-3, atol=1e-4)
+            dtype='d', atol=1e-2, rtol=3e-2)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.axis, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.gy))

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_layer_normalization.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 def _batch_normalization(expander, gamma, beta, x, mean, var):
@@ -37,10 +36,12 @@ class TestLayerNormalization(unittest.TestCase):
                     for _ in self.args]
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {'atol': 5e-1, 'rtol': 1e-1}
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, args):
         x_data = args[0]
@@ -58,12 +59,10 @@ class TestLayerNormalization(unittest.TestCase):
         testing.assert_allclose(
             y.data, unbatched_concat_y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.args)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward([cuda.to_gpu(_) for _ in self.args])
 
@@ -75,12 +74,10 @@ class TestLayerNormalization(unittest.TestCase):
             func, args, y_grad,
             eps=1e-2, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.args, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(
             [cuda.to_gpu(_) for _ in self.args],
@@ -93,14 +90,12 @@ class TestLayerNormalization(unittest.TestCase):
 
         gradient_check.check_double_backward(
             func, args, y_grad, x_grad_grad,
-            eps=1e-2, **self.check_backward_options)
+            eps=1e-2, **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.args, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             [cuda.to_gpu(_) for _ in self.args],

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -12,7 +12,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import conv
 from chainer_tests.functions_tests.pooling_tests import pooling_nd_helper
 
@@ -43,7 +42,7 @@ class TestAveragePoolingND(unittest.TestCase):
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'eps': 1e-1, 'atol': 5e-3, 'rtol': 5e-2}
+                'eps': 1e-2, 'atol': 5e-3, 'rtol': 5e-2}
 
     def check_forward(self, x_data, use_cudnn='always'):
         dims = self.dims
@@ -68,22 +67,18 @@ class TestAveragePoolingND(unittest.TestCase):
                 testing.assert_allclose(
                     expect, y_data[k, c], **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.cudnn
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.cudnn
-    @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), 'never')
 
@@ -104,17 +99,14 @@ class TestAveragePoolingND(unittest.TestCase):
                                                 pad=pad)
         testing.assert_allclose(y_nd.data, y_2d.data)
 
-    @condition.retry(3)
     def test_forward_consistency_regression_cpu(self):
         self.check_forward_consistency_regression(self.x)
 
     @attr.cudnn
-    @condition.retry(3)
     def test_forward_consistency_regression_gpu(self):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_consistency_regression_no_cudnn(self):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x), 'never')
 
@@ -123,26 +115,23 @@ class TestAveragePoolingND(unittest.TestCase):
             gradient_check.check_backward(
                 functions.AveragePoolingND(
                     self.ndim, self.ksize, self.stride, self.pad),
-                x_data, y_grad, **self.check_backward_options)
+                x_data, y_grad, dtype=numpy.float64,
+                **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.cudnn
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.cudnn
-    @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(
             cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
             cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
@@ -179,18 +168,15 @@ class TestAveragePoolingND(unittest.TestCase):
         # Test that the two result gradients are close enough.
         testing.assert_allclose(x_nd.grad, x_2d.grad)
 
-    @condition.retry(3)
     def test_backward_consistency_regression_cpu(self):
         self.check_backward_consistency_regression(self.x, self.gy)
 
     @attr.cudnn
-    @condition.retry(3)
     def test_backward_consistency_regression_gpu(self):
         self.check_backward_consistency_regression(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_consistency_regression_no_cudnn(self):
         self.check_backward_consistency_regression(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), use_cudnn='never')

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -10,7 +10,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -33,6 +32,17 @@ class TestMaxPooling2D(unittest.TestCase):
                 -1, 1, (2, 3, 2, 2)).astype(self.dtype)
         self.ggx = numpy.random.uniform(
             -1, 1, (2, 3, 4, 3)).astype(self.dtype)
+
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {
+                'atol': 1e-3, 'rtol': 1e-2}
+            self.check_double_backward_options = {
+                'atol': 1e-3, 'rtol': 1e-2}
+        else:
+            self.check_backward_options = {
+                'atol': 1e-4, 'rtol': 1e-3}
+            self.check_double_backward_options = {
+                'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
@@ -57,7 +67,6 @@ class TestMaxPooling2D(unittest.TestCase):
                         [x[1:4, 0:2].max(), x[1:4, 1:3].max()]])
                 testing.assert_allclose(expect, y_data[k, c])
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
@@ -81,17 +90,14 @@ class TestMaxPooling2D(unittest.TestCase):
             functions.max_pooling_2d(x, 3, stride=2)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_non_contiguous(self):
         self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)))
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), 'never')
 
@@ -135,26 +141,23 @@ class TestMaxPooling2D(unittest.TestCase):
                 x, 3, stride=2, pad=1, cover_all=self.cover_all)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
-                f, x_data, y_grad, dtype='d', atol=1e-4, rtol=1e-3)
+                f, x_data, y_grad, dtype='d',
+                **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_non_contiguous(self):
         self.check_backward(
             cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
             cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
 
@@ -174,20 +177,18 @@ class TestMaxPooling2D(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad,
-                dtype='d', atol=1e-4, rtol=1e-3)
+                dtype='d',
+                **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx, 'never')
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu_non_contiguous(self):
         self.check_double_backward(
             cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
@@ -195,7 +196,6 @@ class TestMaxPooling2D(unittest.TestCase):
             cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu_no_cudnn(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),


### PR DESCRIPTION
I couldn't fix the following tests because those discrepancies are seemingly too large.
* TestBatchNormalization.test_double_backward_cpu
* TestBatchRenormalization.test_backward_cpu
* TestBatchRenormalization.test_forward_cpu
* TestDeconvolution2DFunction.test_backward_cpu
* TestDeconvolutionND.test_backward_cpu
* TestFixedBatchRenormalization.test_backward_cpu
* TestNStepBiRNN.test_backward_cpu
* TestNStepRNN.test_backward_cpu
