### PR TITLE
Fix numerical instabilities

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -9,7 +9,6 @@ from chainer import functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import type_check
 
 
@@ -37,6 +36,8 @@ class DetFunctionTest(unittest.TestCase):
             self.det = F.det
             self.matmul = F.matmul
 
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+
     def det_transpose(self, gpu=False):
         if gpu:
             cx = cuda.to_gpu(self.x)
@@ -51,11 +52,9 @@ class DetFunctionTest(unittest.TestCase):
         testing.assert_allclose(yn.data, yt.data, rtol=1e-4, atol=1)
 
     @attr.gpu
-    @condition.retry(3)
     def test_det_transpose_gpu(self):
         self.det_transpose(gpu=True)
 
-    @condition.retry(3)
     def test_det_transpose_cpu(self):
         self.det_transpose(gpu=False)
 
@@ -75,11 +74,9 @@ class DetFunctionTest(unittest.TestCase):
         testing.assert_allclose(cxd.data * c, sxd.data)
 
     @attr.gpu
-    @condition.retry(3)
     def test_det_scaling_gpu(self):
         self.det_scaling(gpu=True)
 
-    @condition.retry(3)
     def test_det_scaling_cpu(self):
         self.det_scaling(gpu=False)
 
@@ -119,26 +116,26 @@ class DetFunctionTest(unittest.TestCase):
         testing.assert_allclose(
             dxy1.data, dxy2.data, rtol=1e-4, atol=1e-4)
 
-    @condition.retry(3)
     def test_det_product_cpu(self):
         self.det_product(gpu=False)
 
     @attr.gpu
-    @condition.retry(3)
     def test_det_product_gpu(self):
         self.det_product(gpu=True)
 
     @attr.gpu
-    @condition.retry(3)
     def test_batch_backward_gpu(self):
         x_data = cuda.to_gpu(self.x)
         y_grad = cuda.to_gpu(self.gy)
-        gradient_check.check_backward(self.det, x_data, y_grad)
+        gradient_check.check_backward(
+            self.det, x_data, y_grad,
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_batch_backward_cpu(self):
         x_data, y_grad = self.x, self.gy
-        gradient_check.check_backward(self.det, x_data, y_grad)
+        gradient_check.check_backward(
+            self.det, x_data, y_grad,
+            **self.check_backward_options)
 
     def check_single_matrix(self, x):
         x = chainer.Variable(x)
@@ -177,7 +174,9 @@ class DetFunctionTest(unittest.TestCase):
         else:
             x[...] = 0.0
         with self.assertRaises(err):
-            gradient_check.check_backward(self.det, x, gy)
+            gradient_check.check_backward(
+                self.det, x, gy,
+                **self.check_backward_options)
 
     def test_zero_det_cpu(self):
         self.check_zero_det(self.x, self.gy, ValueError)
@@ -198,12 +197,10 @@ class TestDetSmallCase(unittest.TestCase):
         y = x[0, 0] * x[1, 1] - x[0, 1] * x[1, 0]
         testing.assert_allclose(ans, y)
 
-    @condition.retry(3)
     def test_answer_cpu(self):
         self.check_by_definition(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_answer_gpu(self):
         self.check_by_definition(cuda.to_gpu(self.x))
 
@@ -218,7 +215,6 @@ class TestDetGPUCPUConsistency(unittest.TestCase):
         self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
 
     @attr.gpu
-    @condition.retry(3)
     def test_answer_gpu_cpu(self):
         x = cuda.to_gpu(self.x)
         y = F.det(chainer.Variable(x))
@@ -238,7 +234,6 @@ class TestBatchDetGPUCPUConsistency(unittest.TestCase):
         self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
 
     @attr.gpu
-    @condition.retry(3)
     def test_answer_gpu_cpu(self):
         x = cuda.to_gpu(self.x)
         y = F.batch_det(chainer.Variable(x))

--- a/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -20,30 +19,30 @@ class Expm1FunctionTest(unittest.TestCase):
         self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
 
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = F.expm1(x)
         testing.assert_allclose(
             numpy.expm1(self.x), y.data, atol=1e-7, rtol=1e-7)
 
-    @condition.retry(3)
     def test_expm1_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_expm1_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(F.expm1, x_data, y_grad)
+        gradient_check.check_backward(
+            F.expm1, x_data, y_grad,
+            **self.check_backward_options)
 
-    @condition.retry(3)
     def test_expm1_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_expm1_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -13,15 +13,22 @@ from chainer.testing import attr
 class TestMax(unittest.TestCase):
 
     def setUp(self):
+        eps = 1e-5
+
         # Sample x with single maximum value
         while True:
             self.x = numpy.random.uniform(
                 -1, 1, (3, 2, 4)).astype(numpy.float32)
-            if (self.x > (numpy.max(self.x) - 1e-2)).sum() == 1:
+            if (self.x > (numpy.max(self.x) - 2 * eps)).sum() == 1:
                 break
 
         self.gy = numpy.array(2, dtype=numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+
+        self.check_backward_options = {
+            'eps': eps, 'atol': 1e-3, 'rtol': 1e-2}
+        self.check_double_backward_options = {
+            'eps': eps, 'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, x_data, axis=None, keepdims=False):
         x = chainer.Variable(x_data)
@@ -85,7 +92,8 @@ class TestMax(unittest.TestCase):
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
             lambda x: functions.max(x, axis, keepdims),
-            x_data, y_grad, dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
+            x_data, y_grad, dtype='d',
+            **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
@@ -158,8 +166,8 @@ class TestMax(unittest.TestCase):
             return x * x
 
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad,
-            dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
+            f, x_data, y_grad, x_grad_grad, dtype='d',
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
@@ -189,15 +197,22 @@ class TestMax(unittest.TestCase):
 class TestMin(unittest.TestCase):
 
     def setUp(self):
+        eps = 1e-5
+
         # Sample x with single minimum value
         while True:
             self.x = numpy.random.uniform(
                 -1, 1, (3, 2, 4)).astype(numpy.float32)
-            if (self.x < (numpy.min(self.x) + 1e-2)).sum() == 1:
+            if (self.x < (numpy.min(self.x) + 2 * eps)).sum() == 1:
                 break
 
         self.gy = numpy.array(2, dtype=numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 2, 4)).astype(numpy.float32)
+
+        self.check_backward_options = {
+            'eps': eps, 'atol': 1e-3, 'rtol': 1e-2}
+        self.check_double_backward_options = {
+            'eps': eps, 'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, x_data, axis=None, keepdims=False):
         x = chainer.Variable(x_data)
@@ -261,7 +276,8 @@ class TestMin(unittest.TestCase):
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
             lambda x: functions.min(x, axis=axis, keepdims=keepdims),
-            x_data, y_grad, dtype='d', eps=1e-4, rtol=1e-3, atol=1e-3)
+            x_data, y_grad, dtype='d',
+            **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
@@ -334,8 +350,8 @@ class TestMin(unittest.TestCase):
             return x * x
 
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad,
-            dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
+            f, x_data, y_grad, x_grad_grad, dtype='d',
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)


### PR DESCRIPTION
Sometimes theses tests fail with large discrepancy, which I couldn't fix.

* TestMin.test_backward_multi_axis_invert_cpu
* TestMin.test_backward_negative_multi_axis_invert_cpu
* TestMax.test_backward_multi_axis_invert_cpu
* TestMax.test_backward_negative_multi_axis_invert_cpu
