### PR TITLE
Remove dtype=numpy.float64 from check_double_backward in test_embed_id

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_embed_id.py
@@ -77,7 +77,7 @@ class TestEmbedID(unittest.TestCase):
             return y * y
 
         gradient_check.check_double_backward(
-            f,  W_data, gy_data, ggW_data, dtype=numpy.float64,
+            f,  W_data, gy_data, ggW_data,
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):


### PR DESCRIPTION
This has caused CUDA compilation error.